### PR TITLE
Enable comparison across different schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,8 @@ export PATH=$PATH:$GOBIN
 ```
 comp-mysql-checksums -f ./config.yaml -p 4 -s ${Target Database Schema}
 ```
+
+比較対象のSchemaを別にしたい場合は引数を変える
+```
+comp-mysql-checksums -f ./config.yaml -p 4 -ss ${Target Database Schema 1} -st ${Target Database Schema 2}
+```

--- a/main.go
+++ b/main.go
@@ -106,13 +106,19 @@ func main() {
 	configFile := flag.String("f", "", "Path to the YAML configuration file")
 	parallelism := flag.Int("p", 1, "Number of parallel threads")
 	schema := flag.String("s", "", "Schema name")
+	schemaSource := flag.String("ss", "", "Schema of source")
+	schemaTarget := flag.String("st", "", "Schema of target")
 	flag.Parse()
 
 	if *configFile == "" {
 		log.Fatal("Please specify a configuration file")
 	}
-	if *schema == "" {
-		log.Fatal("Please specify a schema name")
+	if *schema == "" && (*schemaSource == "" || *schemaTarget == ""){
+		log.Fatal("Please specify a schema")
+	}
+	if *schema != "" {
+		*schemaSource = *schema
+		*schemaTarget = *schema
 	}
 
 	yamlFile, err := os.ReadFile(*configFile)
@@ -134,12 +140,12 @@ func main() {
 
 	go func() {
 		defer wg.Done() // 処理が終了したら、カウンタをデクリメント
-		checksums1, err1 = getTableChecksums(config.Server1.DSN, *schema, *parallelism)
+		checksums1, err1 = getTableChecksums(config.Server1.DSN, *schemaSource, *parallelism)
 	}()
 
 	go func() {
 		defer wg.Done() // 処理が終了したら、カウンタをデクリメント
-		checksums2, err2 = getTableChecksums(config.Server2.DSN, *schema, *parallelism)
+		checksums2, err2 = getTableChecksums(config.Server2.DSN, *schemaTarget, *parallelism)
 	}()
 
 	wg.Wait() // すべてのgoroutineが終了するまで待つ


### PR DESCRIPTION
# 背景
同一筐体ないでデータタイプが異なるデータを別スキーマに配置して、元のデータタイプとの比較を取るというユースケースがありました。

# 対応
引数でそれぞれのスキーマを定義できるようにしています